### PR TITLE
Align number columns in table to the right

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ around the OpenligaDB API (http://www.openligadb.de).
 
 ### Using pip
 
-To install JiraCards:
+To install bundesliga-cli:
 
     $ sudo pip install bundesliga-cli
 

--- a/bundesliga/bundesliga.py
+++ b/bundesliga/bundesliga.py
@@ -20,8 +20,15 @@ def create_results_table():
 
 
 def create_table_table():
-    x = PrettyTable(["Rank", "Club", "Matches", "Wins", "Draws", "Losses", "Goals", "GD", "Points"])
+    x = PrettyTable(["Rank", "Club", "Matches", "Wins", "Draws", "Losses", "Goals", "GD", "Points"], align="r")
+    x.align["Rank"] = "r"
     x.align["Club"] = "l"
+    x.align["Matches"] = "r"
+    x.align["Wins"] = "r"
+    x.align["Draws"] = "r"
+    x.align["Losses"] = "r"
+    x.align["GD"] = "r"
+    x.align["Points"] = "r"
     return x
 
 


### PR DESCRIPTION
Personally I find that aligning columns that contain numbers to the right slightly improves readability, at least when number with one digit and two digits are mixed. In case you prefer the formatting as is, just ignore this pull request.

In version 0.7.2 PrettyTable ignores the flag when you pass a default alignment when constructing the table, so the alignment is set explicitly for each column for now. This bug has already been fixed in the trunk version of PrettyTable, but there is no new release yet.

Thanks for creating this tool, it comes in handy.
